### PR TITLE
Conversion to Swift 4

### DIFF
--- a/MCCoreDataStack/Library/CoreDataRepository/Extension/MCCoreDataRepository+Delete.swift
+++ b/MCCoreDataStack/Library/CoreDataRepository/Extension/MCCoreDataRepository+Delete.swift
@@ -60,7 +60,7 @@ internal extension MCCoreDataRepository {
     }
     
     internal func _delete(containedInArray array: [NSManagedObject],
-                                           completionBlock: ((Void) -> Void)?) {
+                          completionBlock: (() -> Void)?) {
         
         weak var weakSelf = self
         
@@ -77,7 +77,7 @@ internal extension MCCoreDataRepository {
     }
 
     internal func _deleteIDs(containedInArray array: [NSManagedObjectID],
-                                         completionBlock: ((Void) -> Void)?) {
+                             completionBlock: (() -> Void)?) {
         
         weak var weakSelf = self
         

--- a/MCCoreDataStack/Library/CoreDataRepository/Extension/MCCoreDataRepository+Fetch.swift
+++ b/MCCoreDataStack/Library/CoreDataRepository/Extension/MCCoreDataRepository+Fetch.swift
@@ -10,65 +10,69 @@ import Foundation
 import CoreData
 
 public extension MCCoreDataRepository {
-        
-    //MARK Fetching in currentQueue
-    
-    //MARK: Fetching
+
+    // MARK: - Fetching in currentQueue
+
+    // MARK: Fetching
     ///### fetch all the objects by EntityName in the current thread
     ///- Parameter entityName: Name of the corresponding entity
-    ///- Parameter context: ManagedObjectContext created in the current thread. If nil the call should be from the main Thread
+    ///- Parameter context: ManagedObjectContext created in the current thread. If nil the call should be from the
+    ///     main Thread
     ///- Parameter resultType: this can be  .ManagedObject .ManagedObjectID .Dictionary .Count
     ///- Return: New NSManagedObject or nil
-    
-    public func fetch(entityName: String, context: NSManagedObjectContext, resultType: NSFetchRequestResultType) -> [AnyObject]? {
+
+    public func fetch(entityName: String,
+                      context: NSManagedObjectContext,
+                      resultType: NSFetchRequestResultType) -> [AnyObject]? {
+
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
         fetchRequest.resultType = resultType
-        
+
         #if DEBUG
-            fetchRequest.returnsObjectsAsFaults = false;
+            fetchRequest.returnsObjectsAsFaults = false
         #endif
-        
+
         do {
             let results = try context.fetch(fetchRequest)
-            
-            return results as [AnyObject];
+            return results as [AnyObject]
+
         } catch {
-            //Nothing to do here
+            print("Fetch failed: \(error.localizedDescription)")
         }
+
         return []
     }
 
-    
     ///### fetch all the object of a specific entityName, by Predicate, in the current thread
     ///- Parameter predicate: NSPredicate object
     ///- Parameter entityName: Name of the corresponding entity
-    ///- Parameter context: ManagedObjectContext created in the current thread. If nil the call should be from the main Thread
+    ///- Parameter context: ManagedObjectContext created in the current thread. If nil the call should be from the
+    ///     main Thread
     ///- Parameter resultType: this can be  .ManagedObject .ManagedObjectID .Dictionary .Count
     ///- Return: array of results
-    
-    public func fetch(byPredicate predicate: NSPredicate, entityName: String, context: NSManagedObjectContext, resultType: NSFetchRequestResultType) -> [AnyObject]? {
+
+    public func fetch(byPredicate predicate: NSPredicate,
+                      entityName: String,
+                      context: NSManagedObjectContext,
+                      resultType: NSFetchRequestResultType) -> [AnyObject]? {
+
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>()
         fetchRequest.predicate = predicate
         fetchRequest.resultType = resultType
-        
-        let entityDescription = NSEntityDescription.entity(forEntityName: entityName, in: context)
-        
+        fetchRequest.entity = NSEntityDescription.entity(forEntityName: entityName, in: context)
+
         #if DEBUG
-            fetchRequest.returnsObjectsAsFaults = false;
+            fetchRequest.returnsObjectsAsFaults = false
         #endif
 
-        var results: [AnyObject]? = nil
-        fetchRequest.entity = entityDescription;
-        
         do {
-            results = try context.fetch(fetchRequest)
-            
+            let results: [AnyObject]? = try context.fetch(fetchRequest)
             return results
+
         } catch let error as NSError {
             print("Fetch failed: \(error.localizedDescription)")
-            //Nothing to do here
         }
+
         return []
     }
-        
 }

--- a/MCCoreDataStack/Library/CoreDataRepository/Extension/NSManagedObject+Create.swift
+++ b/MCCoreDataStack/Library/CoreDataRepository/Extension/NSManagedObject+Create.swift
@@ -35,10 +35,12 @@ extension NSManagedObject: EUManagedObjectProtocol {
         for (key, value) in dictionary {
 
             if value is [[String: AnyObject]] {
+                // swiftlint:disable:next force_cast
                 self.update(keyName: key, array: value as! [[String: AnyObject]])
 
             } else if value is [String: AnyObject] {
                 let array = [value]
+                // swiftlint:disable:next force_cast
                 self.update(keyName: key, array: array as! [[String: AnyObject]])
 
             } else if self.responds(to: NSSelectorFromString(key)) {
@@ -47,6 +49,7 @@ extension NSManagedObject: EUManagedObjectProtocol {
                     self.setValue(value, forKey: key)
                 case is DateComponents:
                     let dateComponents = value
+                    // swiftlint:disable:next force_cast
                     self.setValue((dateComponents as! NSDateComponents).date, forKey: key)
                 default:
                     self.setValue(value, forKey: key)

--- a/MCCoreDataStack/Library/CoreDataRepository/Extension/NSManagedObject+Create.swift
+++ b/MCCoreDataStack/Library/CoreDataRepository/Extension/NSManagedObject+Create.swift
@@ -37,11 +37,11 @@ extension NSManagedObject: EUManagedObjectProtocol {
             if value is [[String: AnyObject]] {
                 self.update(keyName: key, array: value as! [[String: AnyObject]])
 
-            } else if (value is [String: AnyObject]) {
+            } else if value is [String: AnyObject] {
                 let array = [value]
                 self.update(keyName: key, array: array as! [[String: AnyObject]])
 
-            } else if (self.responds(to: NSSelectorFromString(key))) {
+            } else if self.responds(to: NSSelectorFromString(key)) {
                 switch value {
                 case is String:
                     self.setValue(value, forKey: key)

--- a/MCCoreDataStack/Library/CoreDataRepository/Extension/NSManagedObject+Create.swift
+++ b/MCCoreDataStack/Library/CoreDataRepository/Extension/NSManagedObject+Create.swift
@@ -61,7 +61,7 @@ extension NSManagedObject: EUManagedObjectProtocol {
     ///### called when a value is an array of NSManagedObjects. To be overridden
     ///- Parameter array: array of dictionaries
 
-    public func update(keyName: String, array: Array<Dictionary<String, AnyObject>>) {
+    @objc public func update(keyName: String, array: Array<Dictionary<String, AnyObject>>) {
         // To be overridden by subclasses
     }
 

--- a/MCCoreDataStack/Library/CoreDataRepository/Extension/NSManagedObject+Create.swift
+++ b/MCCoreDataStack/Library/CoreDataRepository/Extension/NSManagedObject+Create.swift
@@ -10,59 +10,55 @@ import Foundation
 import CoreData
 
 extension NSManagedObject: EUManagedObjectProtocol {
-    
-    //MARK: Extension to auto populate properties from a dictionary
-    
+
+    // MARK: Extension to auto populate properties from a dictionary
+
     ///### Class method to create an Instance of a specific NSManagedObject using a Dictionary
     ///- Parameter dictionary: dictionary
     ///- Parameter entityName: the name of the entity
     ///- Parameter context: NSManagedObjectContext
     ///- Return: NSManagedObject
 
-    @objc public class func instanceWithDictionary(dictionary: Dictionary<String, AnyObject>,
+    @objc public class func instanceWithDictionary(dictionary: [String: AnyObject],
                                                    entityName: String,
                                                    context: NSManagedObjectContext) -> NSManagedObject? {
         let entity = NSEntityDescription.insertNewObject(forEntityName: entityName, into: context)
         entity.updateWithDictionary(dictionary: dictionary)
-        
+
         return entity
     }
-    
+
     ///### Update current NSManagedObject with a dictionary
     ///- Parameter dictionary: dictionary
 
-    @objc public func updateWithDictionary(dictionary: Dictionary<String, AnyObject>) {
+    @objc public func updateWithDictionary(dictionary: [String: AnyObject]) {
         for (key, value) in dictionary {
-            let keyName = key
-            let keyValue: AnyObject = value
-            
-            if value is Array<Dictionary<String, AnyObject>> {
-                
-                self.update(keyName: keyName, array: value as! Array<Dictionary<String, AnyObject>>)
-            } else if (value is Dictionary<String, AnyObject>) {
-                
+
+            if value is [[String: AnyObject]] {
+                self.update(keyName: key, array: value as! [[String: AnyObject]])
+
+            } else if (value is [String: AnyObject]) {
                 let array = [value]
-                self.update(keyName: keyName, array: array as! Array<Dictionary<String, AnyObject>>)
-            } else if (self.responds(to: NSSelectorFromString(keyName))) {
-                
-                if keyValue is String {
-                   let keyValueString = keyValue as! String
-                    self.setValue(keyValueString, forKey: keyName)
-                } else if keyValue is DateComponents {
-                    let dateComponents = keyValue as! DateComponents
-                    self.setValue((dateComponents as NSDateComponents).date, forKey: keyName)
-                } else {
-                    self.setValue(keyValue, forKey: keyName)
+                self.update(keyName: key, array: array as! [[String: AnyObject]])
+
+            } else if (self.responds(to: NSSelectorFromString(key))) {
+                switch value {
+                case is String:
+                    self.setValue(value, forKey: key)
+                case is DateComponents:
+                    let dateComponents = value
+                    self.setValue((dateComponents as! NSDateComponents).date, forKey: key)
+                default:
+                    self.setValue(value, forKey: key)
                 }
             }
         }
     }
-    
+
     ///### called when a value is an array of NSManagedObjects. To be overridden
     ///- Parameter array: array of dictionaries
 
-    @objc public func update(keyName: String, array: Array<Dictionary<String, AnyObject>>) {
+    @objc public func update(keyName: String, array: [[String: AnyObject]]) {
         // To be overridden by subclasses
     }
-
 }

--- a/MCCoreDataStack/Library/CoreDataRepository/Extension/NSManagedObjectContext+Fetch.swift
+++ b/MCCoreDataStack/Library/CoreDataRepository/Extension/NSManagedObjectContext+Fetch.swift
@@ -10,65 +10,57 @@ import Foundation
 import CoreData
 
 extension NSManagedObjectContext {
-    
-    //MARK: Fetch existing Objects
+
+    // MARK: Fetch existing Objects
 
     ///### fetch all the objects from an array of NSManagedObjectID
     ///- Parameter managedObjects: Array of NSManagedObjectIDs
     ///- Return: Array of NSManagedObjects
 
-    @objc public func existingObjecsWithIds(managedObjects objectIDArray:[NSManagedObjectID]) -> [NSManagedObject] {
-        
+    @objc public func existingObjecsWithIds(managedObjects objectIDArray: [NSManagedObjectID]) -> [NSManagedObject] {
+
         var objects: [NSManagedObject] = []
-        
+
         for objectID in objectIDArray {
-            
             if objectID.isKind(of: NSManagedObjectID.self) {
-                
-                let mo = self.object(with: objectID)
-                objects.append(mo)
-                
+                objects.append(self.object(with: objectID))
             }
         }
+
         return objects
     }
-    
+
     ///### fetch all the objects from an array of NSManagedObjects
     ///- Parameter managedObjects: Array of NSManagedObjects
     ///- Return: Array of NSManagedObjectIDs
 
-    @objc public func existingIdsWith(managedObjects objectIDArray:[NSManagedObject]) -> [NSManagedObjectID] {
-        
+    @objc public func existingIdsWith(managedObjects objectIDArray: [NSManagedObject]) -> [NSManagedObjectID] {
+
         var objects: [NSManagedObjectID] = []
-        
+
         for object in objectIDArray {
-            
             if object.isKind(of: NSManagedObject.self) {
-                
                 objects.append(object.objectID)
-                
             }
         }
+
         return objects
     }
-    
+
     ///### Move array of NSManagedObject in the current Managed Object Context
     ///- Parameter managedObjects: Array of NSManagedObjects
     ///- Return: Array of NSManagedObjects in the current context
 
-    @objc public func moveInContext(managedObjects objectIDArray:[NSManagedObject]) -> [NSManagedObject] {
-        
+    @objc public func moveInContext(managedObjects objectIDArray: [NSManagedObject]) -> [NSManagedObject] {
+
         var objects: [NSManagedObject] = []
-        
+
         for object in objectIDArray {
-            
             if object.isKind(of: NSManagedObject.self) {
-                
-                let mo = self.object(with: object.objectID)
-                objects.append(mo)
-                
+                objects.append(self.object(with: object.objectID))
             }
         }
+
         return objects
     }
 }

--- a/MCCoreDataStack/Library/CoreDataRepository/Extension/NSManagedObjectContext+Save.swift
+++ b/MCCoreDataStack/Library/CoreDataRepository/Extension/NSManagedObjectContext+Save.swift
@@ -30,7 +30,7 @@ extension NSManagedObjectContext {
                 } catch {
                     completionBlock ({
                         let error = "We encountered a problem. Changes could not be saved."
-                        throw CoreDataStackError.Error(description: error)
+                        throw CoreDataStackError.error(description: error)
                     })
 
                     return
@@ -57,7 +57,7 @@ extension NSManagedObjectContext {
                 } catch {
                     completionBlock ({
                         let error = "We encountered a problem. Changes could not be saved."
-                        throw CoreDataStackError.Error(description: error)
+                        throw CoreDataStackError.error(description: error)
                     })
 
                     return

--- a/MCCoreDataStack/Library/CoreDataRepository/Extension/NSManagedObjectContext+Save.swift
+++ b/MCCoreDataStack/Library/CoreDataRepository/Extension/NSManagedObjectContext+Save.swift
@@ -10,69 +10,61 @@ import Foundation
 import CoreData
 
 extension NSManagedObjectContext {
-    
-    //MARK: Save new objects
-    
+
+    // MARK: Save new objects
+
     ///### Save the current context in a background queue
     ///- Parameter completionBlock: The completion Block
 
-    public func save(completionBlock: @escaping MCCoreDataAsyncResult) -> Void {
-        
-        self.performAndWait({ [weak self] in
-            
+    public func save(completionBlock: @escaping MCCoreDataAsyncResult) {
+
+        self.performAndWait { [weak self] in
             guard let strongSelf = self else {
                 completionBlock({ })
                 return
             }
-            
+
             if strongSelf.hasChanges {
-                
                 do {
-                    
                     try strongSelf.save()
-                    
-                    completionBlock({ })
-                    
                 } catch {
                     completionBlock ({
-                        throw CoreDataStackError.internalError(description: "We encountered a problem. Changes could not be saved.")
+                        let error = "We encountered a problem. Changes could not be saved."
+                        throw CoreDataStackError.Error(description: error)
                     })
+
+                    return
                 }
-            } else {
-                completionBlock({ })
             }
-            
-        })
+
+            completionBlock({ })
+        }
     }
-    
+
     ///### Save the current context and wait
 
-    public func saveAndWait(completionBlock: @escaping MCCoreDataAsyncResult) -> Void {
-        
-        self.performAndWait({ [weak self] in
-            
+    public func saveAndWait(completionBlock: @escaping MCCoreDataAsyncResult) {
+
+        self.performAndWait { [weak self] in
             guard let strongSelf = self else {
                 completionBlock({ })
                 return
             }
-            
+
             if strongSelf.hasChanges {
-                
                 do {
-                    
                     try strongSelf.save()
-                    
-                    completionBlock({ })
-                    
                 } catch {
                     completionBlock ({
-                        throw CoreDataStackError.internalError(description: "We encountered a problem. Changes could not be saved.")
+                        let error = "We encountered a problem. Changes could not be saved."
+                        throw CoreDataStackError.Error(description: error)
                     })
+
+                    return
                 }
-            } else {
-                completionBlock({ })
             }
-        })
+
+            completionBlock({ })
+        }
     }
-    
 }

--- a/MCCoreDataStack/Library/CoreDataRepository/MCCoreDataRepository.swift
+++ b/MCCoreDataStack/Library/CoreDataRepository/MCCoreDataRepository.swift
@@ -9,25 +9,27 @@
 import Foundation
 import CoreData
 
-@objc open class MCCoreDataRepository : NSObject {
-    
-    //MARK: Public vars
-    ///### Internal CoreDataStackManager
+@objc open class MCCoreDataRepository: NSObject {
 
-    @objc fileprivate(set) open var cdsManager: MCCoreDataStackManager! = nil
-    
-    //MARK: Setup
-    
+    // MARK: Public vars
+    ///###  CoreDataStackManager
+
+    @objc private(set) open var cdsManager: MCCoreDataStackManager!
+
+    // MARK: Setup
+
     ///### Setup a coreDataRepository. It looks up all models in the specified bundles and merges them
     ///- Parameter storeNameURL: URL of the sql store
     ///- Parameter modelNameURL: URL of the model
     ///- Parameter domainName: Domain Name
     ///- Return: Bool
-    
-    @objc open func setup(storeNameURL: URL, modelNameURL: URL, domainName: String, completion: MCCoreDataAsyncCompletion?) {
-        
+
+    @objc open func setup(storeNameURL: URL,
+                          modelNameURL: URL,
+                          domainName: String,
+                          completion: MCCoreDataAsyncCompletion?) {
+
         self.cdsManager = MCCoreDataStackManager(domain: domainName, url: modelNameURL)!
-        
         self.cdsManager.configure(url: storeNameURL, configuration: nil, completion: completion)
     }
 
@@ -36,15 +38,15 @@ import CoreData
     ///- Parameter domainName: Domain Name
     ///- Return: Bool
 
-    @available(*, deprecated) @objc open func setup(storeName: String, domainName: String, completion: MCCoreDataAsyncCompletion?) {
+    @available(*, deprecated)
+    @objc open func setup(storeName: String, domainName: String, completion: MCCoreDataAsyncCompletion?) {
         let dirPath = StackManagerHelper.Path.DocumentsFolder
         let defaultStoreURL = URL(fileURLWithPath: dirPath + ("/"+storeName))
-        
+
         let bundle = Bundle(for: type(of: self))
         let managedObjectModel = NSManagedObjectModel.mergedModel(from: [bundle])!
-        
+
         self.cdsManager = MCCoreDataStackManager(domain: domainName, model: managedObjectModel)
-        
         self.cdsManager.configure(url: defaultStoreURL, configuration: nil, completion: completion)
     }
 
@@ -53,69 +55,71 @@ import CoreData
     ///- Parameter modelName: Name of the data Model
     ///- Parameter domainName: Domain Name
     ///- Return: Bool
-    
-    @objc open func setup(storeName: String, modelName: String, domainName: String, completion: MCCoreDataAsyncCompletion?) {
-        
+
+    @objc open func setup(storeName: String,
+                          modelName: String,
+                          domainName: String,
+                          completion: MCCoreDataAsyncCompletion?) {
         let dirPath = StackManagerHelper.Path.DocumentsFolder
-        let defaultStoreURL = URL(fileURLWithPath: dirPath + ("/"+storeName))
+        let defaultStoreURL = URL(fileURLWithPath: dirPath + ("/" + storeName))
         let defaultModelURL = Bundle(for: MCCoreDataRepository.self).url(forResource: modelName, withExtension: "momd")!
 
         self.cdsManager = MCCoreDataStackManager(domain: domainName, url: defaultModelURL)!
-        
         self.cdsManager.configure(url: defaultStoreURL, configuration: nil, completion: completion)
     }
-    
-    //MARK: Creation
+
+    // MARK: Creation
     ///### Create a new object from a dictionary
     ///- Parameter entityName: Name of the corresponding entity
     ///- Parameter context: ManagedObjectContext created in the current thread
     ///- Return: New NSManagedObject or nil
-    
-    @discardableResult @objc open func create(dictionary: Dictionary<String, AnyObject>, entityName: String, context: NSManagedObjectContext) -> NSManagedObject? {
+
+    @discardableResult @objc open func create(dictionary: [String: AnyObject],
+                                              entityName: String,
+                                              context: NSManagedObjectContext) -> NSManagedObject? {
         return NSManagedObject.instanceWithDictionary(dictionary: dictionary, entityName: entityName, context: context)
     }
- 
-    //MARK: read
+
+    // MARK: read
     ///### read on a background queue
     ///- Parameter operationBlock
     ///- Parameter completionBlock - The operation is persisted in the disk
     ///- Return: Self - (Chaining support)
 
-    @discardableResult @objc open func read(operationBlock: @escaping (_ context: NSManagedObjectContext) -> Void) -> Self {
+    @discardableResult @objc open func read(operationBlock: @escaping MCCoreDataOperationBlock) -> Self {
         self.cdsManager.read(operationBlock: { (context) in
             operationBlock(context)
         })
-        
+
         return self
     }
 
-    //MARK: write
+    // MARK: write
     ///### write on a background queue
     ///- Parameter operationBlock
     ///- Parameter completionBlock - The operation is persisted in the disk
     ///- Return: Self - (Chaining support)
 
-    @discardableResult @objc open func write(operationBlock: @escaping (_ context: NSManagedObjectContext) -> Void, completion completionBlock: ((NSError?) -> Void)?) -> Self {
+    @discardableResult @objc open func write(operationBlock: @escaping MCCoreDataOperationBlock,
+                                             completion completionBlock: ((NSError?) -> Void)?) -> Self {
         self.cdsManager.write(operationBlock: { (context) in
             operationBlock(context)
-        }) { (error) in
-            
-            if let block = completionBlock {
-                block(error);
-            }
-        }
+        }, completion: { error in
+            completionBlock?(error)
+        })
+
         return self
     }
-    
-    //MARK: read_MT
+
+    // MARK: read_MT
     ///### read from the mainContext on the mainThread
     ///- Parameter operationBlock
 
-    @objc open func read_MT(operationBlock: @escaping (_ context: NSManagedObjectContext) -> Void) -> Void {
-        DispatchQueue.main.async(execute: {
+    @objc open func read_MT(operationBlock: @escaping MCCoreDataOperationBlock) {
+        DispatchQueue.main.async {
             self.cdsManager.read_MT { (context) in
-                    operationBlock(context)
+                operationBlock(context)
             }
-        })
+        }
     }
 }

--- a/MCCoreDataStack/Library/CoreDataRepository/MCCoreDataRepository.swift
+++ b/MCCoreDataStack/Library/CoreDataRepository/MCCoreDataRepository.swift
@@ -111,7 +111,7 @@ import CoreData
     ///### read from the mainContext on the mainThread
     ///- Parameter operationBlock
 
-    @discardableResult @objc open func read_MT(operationBlock: @escaping (_ context: NSManagedObjectContext) -> Void) -> Void {
+    @objc open func read_MT(operationBlock: @escaping (_ context: NSManagedObjectContext) -> Void) -> Void {
         DispatchQueue.main.async(execute: {
             self.cdsManager.read_MT { (context) in
                     operationBlock(context)

--- a/MCCoreDataStack/Library/CoreDataRepository/Protocols/MCManagedObjectProtocol.swift
+++ b/MCCoreDataStack/Library/CoreDataRepository/Protocols/MCManagedObjectProtocol.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 @objc public protocol EUManagedObjectProtocol {
-    
+
     ///### Protocol automatically implemented by NSManagedObject extension
-    func updateWithDictionary(dictionary: Dictionary<String, AnyObject>)
+    func updateWithDictionary(dictionary: [String: AnyObject])
 }

--- a/MCCoreDataStack/Library/CoreDataStackManager/Extensions/MCCoreDataStackManager+Background.swift
+++ b/MCCoreDataStack/Library/CoreDataStackManager/Extensions/MCCoreDataStackManager+Background.swift
@@ -11,76 +11,93 @@ import CoreData
 
 #if TARGET_OS_IPHONE
 
-internal extension MCCoreDataStackManager {
-    
-    internal func deregisterObservers() {
-        if self.areObserversRegistered {
-            NSNotificationCenter.defaultCenter().removeObserver(self, name: UIApplicationWillResignActiveNotification, object: nil)
-            NSNotificationCenter.defaultCenter().removeObserver(self, name: UIApplicationDidEnterBackgroundNotification, object: nil)
-            NSNotificationCenter.defaultCenter().removeObserver(self, name: UIApplicationWillTerminateNotification, object: nil)
-            
-            self.areObserversRegistered = false
+    extension MCCoreDataStackManager {
+
+        func deregisterObservers() {
+            if self.areObserversRegistered {
+                let center = NSNotificationCenter.defaultCenter()
+
+                center.removeObserver(self, name: UIApplicationWillResignActiveNotification, object: nil)
+                center.removeObserver(self, name: UIApplicationDidEnterBackgroundNotification, object: nil)
+                center.removeObserver(self, name: UIApplicationWillTerminateNotification, object: nil)
+
+                self.areObserversRegistered = false
+            }
         }
-    }
-    
-    internal func registerObservers() {
-        if self.areObserversRegistered == false {
-            NSNotificationCenter.defaultCenter().addObserver(self, selector: "_applicationWillResignActive:", name: UIApplicationWillResignActiveNotification, object: nil)
-            NSNotificationCenter.defaultCenter().addObserver(self, selector: "_applicationDidEnterBackground:", name: UIApplicationDidEnterBackgroundNotification, object: nil)
-            NSNotificationCenter.defaultCenter().addObserver(self, selector: "_applicationWillTerminate:", name: UIApplicationWillTerminateNotification, object: nil)
-            self.areObserversRegistered = true
+
+        func registerObservers() {
+            if self.areObserversRegistered == false {
+                let center = NSNotificationCenter.defaultCenter()
+
+                center.addObserver(self,
+                                   selector: "applicationWillResignActive:",
+                                   name: UIApplicationWillResignActiveNotification,
+                                   object: nil)
+                center.addObserver(self,
+                                   selector: "applicationDidEnterBackground:",
+                                   name: UIApplicationDidEnterBackgroundNotification,
+                                   object: nil)
+                center.addObserver(self,
+                                   selector: "applicationWillTerminate:",
+                                   name: UIApplicationWillTerminateNotification,
+                                   object: nil)
+
+                self.areObserversRegistered = true
+            }
         }
-    }
-    
-    //MARK: Observers
-    
-    internal func _applicationWillResignActive(notification: NSNotification) {
-        self.persistbkgcontext()
-    }
-    
-    internal func _applicationDidEnterBackground(notification: NSNotification) {
-        self.persistbkgcontext()
-    }
-    
-    internal func _applicationWillTerminate(notification: NSNotification) {
-        self.persistbkgcontext()
-    }
-    
-    internal func persistbkgcontext() {
-        if UIDevice.currentDevice().respondsToSelector("isMultitaskingSupported") {
-            self.bkgPersistTask = UIBackgroundTaskInvalid
-            NSNotificationCenter.defaultCenter().addObserver(self, selector: "_doBackgroundTask:", name: UIApplicationDidEnterBackgroundNotification, object: nil)
+
+        // MARK: Observers
+
+        func applicationWillResignActive(notification: NSNotification) {
+            self.persistbkgcontext()
         }
-    }
-    
-    internal func _doBackgroundTask(notification: NSNotification) {
-        let app: UIApplication = UIApplication.sharedApplication()
-        weak var weakSelf = self
-        if app.respondsToSelector("beginBackgroundTaskWithExpirationHandler:") {
-            weakSelf!.bkgPersistTask = app.beginBackgroundTaskWithExpirationHandler({() -> Void in
-                if weakSelf!.bkgPersistTask != UIBackgroundTaskInvalid {
-                    app.endBackgroundTask(weakSelf!.bkgPersistTask!)
+
+        func applicationDidEnterBackground(notification: NSNotification) {
+            self.persistbkgcontext()
+        }
+
+        func applicationWillTerminate(notification: NSNotification) {
+            self.persistbkgcontext()
+        }
+
+        func persistbkgcontext() {
+            if UIDevice.currentDevice().respondsToSelector("isMultitaskingSupported") {
+                self.bkgPersistTask = UIBackgroundTaskInvalid
+                NSNotificationCenter.defaultCenter().addObserver(self,
+                                                                 selector: "doBackgroundTask:",
+                                                                 name: UIApplicationDidEnterBackgroundNotification,
+                                                                 object: nil)
+            }
+        }
+
+        func doBackgroundTask(notification: NSNotification) {
+            let app: UIApplication = UIApplication.sharedApplication()
+            weak var weakSelf = self
+            if app.respondsToSelector("beginBackgroundTaskWithExpirationHandler:") {
+                weakSelf!.bkgPersistTask = app.beginBackgroundTaskWithExpirationHandler({() -> Void in
+                    if weakSelf!.bkgPersistTask != UIBackgroundTaskInvalid {
+                        app.endBackgroundTask(weakSelf!.bkgPersistTask!)
+                        self.bkgPersistTask = UIBackgroundTaskInvalid
+                    }
+                })
+                let queue: dispatch_queue_t = dispatch_get_global_queue(DISPATCH_QUMIPE_PRIORITY_DEFAULT, 0)
+                dispatch_async(queue, {() -> Void in
+                    weakSelf?.asyncRead({ (_) -> Void in
+                        weakSelf!.terminateBackgroundTask()
+                    })
+                })
+            }
+        }
+
+        func terminateBackgroundTask() {
+            let app: UIApplication = UIApplication.sharedApplication()
+            if app.respondsToSelector("endBackgroundTask:") {
+                if bkgPersistTask != UIBackgroundTaskInvalid {
+                    app.endBackgroundTask(bkgPersistTask!)
                     self.bkgPersistTask = UIBackgroundTaskInvalid
                 }
-            })
-            let queue: dispatch_queue_t = dispatch_get_global_queue(DISPATCH_QUMIPE_PRIORITY_DEFAULT, 0)
-            dispatch_async(queue, {() -> Void in
-                weakSelf?.asyncRead({ (context) -> Void in
-                    weakSelf!.terminateBackgroundTask()
-                })
-            })
-        }
-    }
-    
-    internal func terminateBackgroundTask() {
-        let app: UIApplication = UIApplication.sharedApplication()
-        if app.respondsToSelector("endBackgroundTask:") {
-            if bkgPersistTask != UIBackgroundTaskInvalid {
-                app.endBackgroundTask(bkgPersistTask!)
-                self.bkgPersistTask = UIBackgroundTaskInvalid
             }
         }
     }
-}
 
 #endif

--- a/MCCoreDataStack/Library/CoreDataStackManager/Extensions/MCCoreDataStackManager+Private.swift
+++ b/MCCoreDataStack/Library/CoreDataStackManager/Extensions/MCCoreDataStackManager+Private.swift
@@ -9,21 +9,21 @@
 import Foundation
 import CoreData
 
-fileprivate enum CDJournalMode: String {
-    case WAL = "WAL"
-    case DELETE = "DELETE"
+private enum CDJournalMode: String {
+    case WAL
+    case DELETE
 }
 
-internal extension MCCoreDataStackManager {
-    
-    internal func createPersistentStoreIfNeeded() {
+ extension MCCoreDataStackManager {
+
+     func createPersistentStoreIfNeeded() {
         guard let model = model else {
             return
         }
 
         if let storeCoordinator = storeCoordinator {
             let stores = storeCoordinator.persistentStores
-            let store = stores.filter{ $0.url == self.storeURL }.first
+            let store = stores.filter { $0.url == self.storeURL }.first
 
             if store != nil {
                 return
@@ -33,9 +33,9 @@ internal extension MCCoreDataStackManager {
 
         self.storeCoordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
     }
-    
-    internal func addSqliteStore(_ storeURL: URL, configuration: String?, completion: MCCoreDataAsyncCompletion?) {
-        createPathToStoreFileIfNeccessary(storeURL);
+
+     func addSqliteStore(_ storeURL: URL, configuration: String?, completion: MCCoreDataAsyncCompletion?) {
+        createPathToStoreFileIfNeccessary(storeURL)
         createContexts()
 
         //lass func global(qos: DispatchQoS.QoSClass)
@@ -85,10 +85,10 @@ fileprivate extension MCCoreDataStackManager {
     }
 
     fileprivate func autoMigrationWithJournalMode(_ mode: String) -> Dictionary<String, AnyObject> {
-        var sqliteOptions = Dictionary<String, AnyObject>()
+        var sqliteOptions = [String: AnyObject]()
         sqliteOptions["journal_mode"] = mode as AnyObject?
 
-        var persistentStoreOptions = Dictionary<String, AnyObject>()
+        var persistentStoreOptions = [String: AnyObject]()
         persistentStoreOptions[NSMigratePersistentStoresAutomaticallyOption] = true as AnyObject?
         persistentStoreOptions[NSInferMappingModelAutomaticallyOption] = true as AnyObject?
         persistentStoreOptions[NSSQLitePragmasOption] = sqliteOptions as AnyObject?
@@ -109,7 +109,7 @@ fileprivate extension MCCoreDataStackManager {
                 return
             }
 
-            rootContext.persistentStoreCoordinator = weakSelf.storeCoordinator;
+            rootContext.persistentStoreCoordinator = weakSelf.storeCoordinator
             rootContext.mergePolicy = NSMergePolicy(merge: .mergeByPropertyObjectTrumpMergePolicyType)
         }
 

--- a/MCCoreDataStack/Library/CoreDataStackManager/Extensions/MCCoreDataStackManager+Private.swift
+++ b/MCCoreDataStack/Library/CoreDataStackManager/Extensions/MCCoreDataStackManager+Private.swift
@@ -44,9 +44,10 @@ private enum CDJournalMode: String {
             do {
                 if let storeCoordinator = self.storeCoordinator {
                     var options = self.autoMigrationWithJournalMode(CDJournalMode.WAL.rawValue)
-                    let sourceMetadata = try? NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: NSSQLiteStoreType,
-                                                                                                      at: storeURL,
-                                                                                                      options: nil)
+                    let coordinator = NSPersistentStoreCoordinator.self
+                    let sourceMetadata = try? coordinator.metadataForPersistentStore(ofType: NSSQLiteStoreType,
+                                                                                     at: storeURL,
+                                                                                     options: nil)
 
                     // Check if we need a migration
                     if let metadata = sourceMetadata {
@@ -84,7 +85,7 @@ fileprivate extension MCCoreDataStackManager {
         }
     }
 
-    fileprivate func autoMigrationWithJournalMode(_ mode: String) -> Dictionary<String, AnyObject> {
+    fileprivate func autoMigrationWithJournalMode(_ mode: String) -> [String: AnyObject] {
         var sqliteOptions = [String: AnyObject]()
         sqliteOptions["journal_mode"] = mode as AnyObject?
 

--- a/MCCoreDataStack/Library/CoreDataStackManager/MCCoreDataStackManager.swift
+++ b/MCCoreDataStack/Library/CoreDataStackManager/MCCoreDataStackManager.swift
@@ -15,7 +15,7 @@ public typealias MCCoreDataOperationBlock = (_ context: NSManagedObjectContext) 
 
 ///###  Error
 public enum CoreDataStackError: Error {
-    case Error(description: String)
+    case error(description: String)
 }
 
 struct Constants {
@@ -333,7 +333,7 @@ public struct StackManagerHelper {
                                     }
                                 })
 
-                            } catch CoreDataStackError.Error(let descr) {
+                            } catch CoreDataStackError.error(let descr) {
 
                                 if let exCompletionBlock = completionBlock {
                                     exCompletionBlock(NSError   (domain:Constants.DomainName, code:-1, userInfo:[
@@ -345,7 +345,7 @@ public struct StackManagerHelper {
 
                         })
 
-                    } catch CoreDataStackError.Error(let descr) {
+                    } catch CoreDataStackError.error(let descr) {
 
                         if let exCompletionBlock = completionBlock {
                             exCompletionBlock(NSError   (domain:Constants.DomainName, code:-1, userInfo:[
@@ -356,7 +356,7 @@ public struct StackManagerHelper {
 
                 })
 
-            } catch CoreDataStackError.Error(let descr) {
+            } catch CoreDataStackError.error(let descr) {
 
                 if let exCompletionBlock = completionBlock {
                     exCompletionBlock(NSError   (domain:Constants.DomainName, code:-1, userInfo:[

--- a/MCCoreDataStack/MCCoreDataStack.xcodeproj/project.pbxproj
+++ b/MCCoreDataStack/MCCoreDataStack.xcodeproj/project.pbxproj
@@ -257,6 +257,7 @@
 				F68FD4A71D6C8BF500E2A56C /* Sources */,
 				F68FD4A81D6C8BF500E2A56C /* Frameworks */,
 				F68FD4A91D6C8BF500E2A56C /* Resources */,
+				0F77046F1F759F5D00A3B1B3 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -375,6 +376,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		0F77046F1F759F5D00A3B1B3 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		F68FD4A71D6C8BF500E2A56C /* Sources */ = {

--- a/MCCoreDataStack/MCCoreDataStack.xcodeproj/project.pbxproj
+++ b/MCCoreDataStack/MCCoreDataStack.xcodeproj/project.pbxproj
@@ -575,7 +575,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = MC.MCCoreDataStack;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
@@ -588,7 +588,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = MC.MCCoreDataStack;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
@@ -601,7 +601,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = MC.MCCoreDataStackTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MCCoreDataStack.app/MCCoreDataStack";
 			};
@@ -615,7 +615,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = MC.MCCoreDataStackTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MCCoreDataStack.app/MCCoreDataStack";
 			};
@@ -628,7 +628,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = MC.MCCoreDataStackUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 4.0;
 				TEST_TARGET_NAME = MCCoreDataStack;
 			};
@@ -641,7 +641,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = MC.MCCoreDataStackUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 4.0;
 				TEST_TARGET_NAME = MCCoreDataStack;
 			};

--- a/MCCoreDataStack/MCCoreDataStack.xcodeproj/project.pbxproj
+++ b/MCCoreDataStack/MCCoreDataStack.xcodeproj/project.pbxproj
@@ -310,21 +310,21 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = MCCoreDataStack;
 				TargetAttributes = {
 					F68FD4AA1D6C8BF500E2A56C = {
 						CreatedOnToolsVersion = 7.3.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 					};
 					F68FD4BE1D6C8BF500E2A56C = {
 						CreatedOnToolsVersion = 7.3.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 						TestTargetID = F68FD4AA1D6C8BF500E2A56C;
 					};
 					F68FD4C91D6C8BF500E2A56C = {
 						CreatedOnToolsVersion = 7.3.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 						TestTargetID = F68FD4AA1D6C8BF500E2A56C;
 					};
 				};
@@ -472,14 +472,20 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -521,14 +527,20 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -563,7 +575,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = MC.MCCoreDataStack;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -575,7 +588,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = MC.MCCoreDataStack;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -587,7 +601,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = MC.MCCoreDataStackTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MCCoreDataStack.app/MCCoreDataStack";
 			};
 			name = Debug;
@@ -600,7 +615,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = MC.MCCoreDataStackTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MCCoreDataStack.app/MCCoreDataStack";
 			};
 			name = Release;
@@ -612,7 +628,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = MC.MCCoreDataStackUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 				TEST_TARGET_NAME = MCCoreDataStack;
 			};
 			name = Debug;
@@ -624,7 +641,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = MC.MCCoreDataStackUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 				TEST_TARGET_NAME = MCCoreDataStack;
 			};
 			name = Release;

--- a/MCCoreDataStack/MCCoreDataStack/AppDelegate.swift
+++ b/MCCoreDataStack/MCCoreDataStack/AppDelegate.swift
@@ -13,34 +13,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
-
-    func applicationWillResignActive(_ application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
-    }
-
-    func applicationDidEnterBackground(_ application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-    }
-
-    func applicationWillEnterForeground(_ application: UIApplication) {
-        // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
-    }
-
-    func applicationDidBecomeActive(_ application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-    }
-
-    func applicationWillTerminate(_ application: UIApplication) {
-        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-    }
-
-
 }
-

--- a/MCCoreDataStack/MCCoreDataStack/ViewController.swift
+++ b/MCCoreDataStack/MCCoreDataStack/ViewController.swift
@@ -20,6 +20,4 @@ class ViewController: UIViewController {
         // Dispose of any resources that can be recreated.
     }
 
-
 }
-

--- a/MCCoreDataStack/MCCoreDataStackTests/CoreDataStackManager/MCCoreDataRepositoryTest.swift
+++ b/MCCoreDataStack/MCCoreDataStackTests/CoreDataStackManager/MCCoreDataRepositoryTest.swift
@@ -60,13 +60,18 @@ class MCCoreDataRepositoryTest: XCTestCase {
 
         self.expectation = self.expectation(description: "Create and save object")
 
-        let subDictionary: [String: AnyObject] = ["subCategoryID": "sub12345" as AnyObject, "subCategoryName": "subTest12345" as AnyObject]
+        let subDictionary: [String: AnyObject] = ["subCategoryID": "sub12345" as AnyObject,
+                                                  "subCategoryName": "subTest12345" as AnyObject]
 
-        let dictionary: [String: AnyObject] = ["categoryID": "12345" as AnyObject, "categoryName": "Test12345" as AnyObject, "subCategory": subDictionary as AnyObject]
+        let dictionary: [String: AnyObject] = ["categoryID": "12345" as AnyObject,
+                                               "categoryName": "Test12345" as AnyObject,
+                                               "subCategory": subDictionary as AnyObject]
 
         self.coreDataRepo.write(operationBlock: { (context) in
 
-            let createdObject = self.coreDataRepo?.create(dictionary: dictionary, entityName: "MCCategoryTest", context: context)
+            let createdObject = self.coreDataRepo?.create(dictionary: dictionary,
+                                                          entityName: "MCCategoryTest",
+                                                          context: context)
 
             XCTAssertFalse(createdObject == nil)
 
@@ -83,7 +88,9 @@ class MCCoreDataRepositoryTest: XCTestCase {
         }) { (_) in
 
         }.read { (context) in
-            let result = self.coreDataRepo?.fetch(entityName: "MCCategoryTest", context: context, resultType: NSFetchRequestResultType())
+            let result = self.coreDataRepo?.fetch(entityName: "MCCategoryTest",
+                                                  context: context,
+                                                  resultType: NSFetchRequestResultType())
 
             for resultItem in result! {
                 let category = resultItem as! MCCategoryTest
@@ -109,12 +116,17 @@ class MCCoreDataRepositoryTest: XCTestCase {
 
         self.expectation = self.expectation(description: "Create and save object")
 
-        let subDictionary: [String: AnyObject] = ["subCategoryID": "sub12345" as AnyObject, "subCategoryName": "subTest12345" as AnyObject]
+        let subDictionary: [String: AnyObject] = ["subCategoryID": "sub12345" as AnyObject,
+                                                  "subCategoryName": "subTest12345" as AnyObject]
 
-        let dictionary: [String: AnyObject] = ["categoryID": "12345" as AnyObject, "categoryName": "Test12345" as AnyObject, "subCategory": subDictionary as AnyObject]
+        let dictionary: [String: AnyObject] = ["categoryID": "12345" as AnyObject,
+                                               "categoryName": "Test12345" as AnyObject,
+                                               "subCategory": subDictionary as AnyObject]
 
         self.coreDataRepo.write(operationBlock: { (context) in
-            let createdObject = self.coreDataRepo?.create(dictionary: dictionary, entityName: "MCCategoryTest", context: context)
+            let createdObject = self.coreDataRepo?.create(dictionary: dictionary,
+                                                          entityName: "MCCategoryTest",
+                                                          context: context)
 
             XCTAssertFalse(createdObject == nil)
 
@@ -135,7 +147,9 @@ class MCCoreDataRepositoryTest: XCTestCase {
 
         }.write(operationBlock: { (context) in
 
-                let results = self.coreDataRepo?.fetch(entityName: "MCCategoryTest", context: context, resultType: NSFetchRequestResultType()) as? [NSManagedObject]
+                let results = self.coreDataRepo?.fetch(entityName: "MCCategoryTest",
+                                                       context: context,
+                                                       resultType: NSFetchRequestResultType()) as? [NSManagedObject]
 
                 XCTAssertTrue((results?.count)! > 0)
                 self.coreDataRepo?.delete(containedInArray: results!, context: context)
@@ -145,7 +159,9 @@ class MCCoreDataRepositoryTest: XCTestCase {
         }.read_MT { (context) in
 
             self.coreDataRepo?.read_MT(operationBlock: { (context) in
-                let results = self.coreDataRepo?.fetch(entityName: "MCCategoryTest", context: context, resultType: NSFetchRequestResultType()) as? [NSManagedObject]
+                let results = self.coreDataRepo?.fetch(entityName: "MCCategoryTest",
+                                                       context: context,
+                                                       resultType: NSFetchRequestResultType()) as? [NSManagedObject]
                 XCTAssertTrue(results?.count == 0)
                 self.expectation.fulfill()
             })
@@ -162,26 +178,39 @@ class MCCoreDataRepositoryTest: XCTestCase {
 
         self.expectation = self.expectation(description: "Create and save object")
 
-        let dictionary: [String: AnyObject] = ["categoryID": "12345" as AnyObject, "categoryName": "Test12345" as AnyObject]
-        let dictionaryNew: [String: AnyObject] = ["categoryID": "12345" as AnyObject, "categoryName": "Test" as AnyObject]
+        let dictionary: [String: AnyObject] = ["categoryID": "12345" as AnyObject,
+                                               "categoryName": "Test12345" as AnyObject]
+        let dictionaryNew: [String: AnyObject] = ["categoryID": "12345" as AnyObject,
+                                                  "categoryName": "Test" as AnyObject]
 
         self.coreDataRepo.write(operationBlock: { (context) in
             var firstObject: NSManagedObject? = nil
             var duplicatedObject: NSManagedObject? = nil
 
-            var results = self.coreDataRepo?.fetch(byPredicate: NSPredicate(format: "%K = %@", "categoryID", dictionary["categoryID"] as! String), entityName: "MCCategoryTest", context: context, resultType: .countResultType)
+            let predicate = NSPredicate(format: "%K = %@", "categoryID", dictionary["categoryID"] as! String)
+            var results = self.coreDataRepo?.fetch(byPredicate: predicate,
+                                                   entityName: "MCCategoryTest",
+                                                   context: context,
+                                                   resultType: .countResultType)
 
             if let value = results {
                 if value[0] as! NSInteger == 0 {
-                    firstObject = self.coreDataRepo?.create(dictionary: dictionary, entityName: "MCCategoryTest", context: context)
+                    firstObject = self.coreDataRepo?.create(dictionary: dictionary,
+                                                            entityName: "MCCategoryTest",
+                                                            context: context)
                 }
             }
 
-            results = self.coreDataRepo?.fetch(byPredicate: NSPredicate(format: "%K = %@", "categoryID", dictionaryNew["categoryID"] as! String), entityName: "MCCategoryTest", context: context, resultType: .countResultType)
+            results = self.coreDataRepo?.fetch(byPredicate: predicate,
+                                               entityName: "MCCategoryTest",
+                                               context: context,
+                                               resultType: .countResultType)
 
             if let value = results {
                 if value[0] as! NSInteger == 0 {
-                    duplicatedObject = self.coreDataRepo?.create(dictionary: dictionaryNew, entityName: "MCCategoryTest", context: context)
+                    duplicatedObject = self.coreDataRepo?.create(dictionary: dictionaryNew,
+                                                                 entityName: "MCCategoryTest",
+                                                                 context: context)
                 }
             }
 
@@ -201,7 +230,11 @@ class MCCoreDataRepositoryTest: XCTestCase {
             XCTAssertTrue(error == nil)
 
             self.coreDataRepo.read(operationBlock: { (context) in
-                let results = self.coreDataRepo?.fetch(byPredicate: NSPredicate(format: "%K = %@", "categoryID", "12345"), entityName: "MCCategoryTest", context: context, resultType: NSFetchRequestResultType())
+                let predicate = NSPredicate(format: "%K = %@", "categoryID", "12345")
+                let results = self.coreDataRepo?.fetch(byPredicate: predicate,
+                                                       entityName: "MCCategoryTest",
+                                                       context: context,
+                                                       resultType: NSFetchRequestResultType())
 
                 if let value = results {
                     XCTAssertTrue(value.count == 1)
@@ -225,7 +258,8 @@ class MCCoreDataRepositoryTest: XCTestCase {
     func testPersist1000CategoriesWithCommonCategoryNameAndRetrieveThemByCategoryName_05() {
         self.expectation = self.expectation(description: "Saving 1000 categories in a background queue")
 
-        let dictionary: [String: AnyObject] = ["categoryID": "12345" as AnyObject, "categoryName": "Test12345" as AnyObject]
+        let dictionary: [String: AnyObject] = ["categoryID": "12345" as AnyObject,
+                                               "categoryName": "Test12345" as AnyObject]
 
         self.coreDataRepo.write(operationBlock: { (context) in
             _ = self.coreDataRepo?.create(dictionary: dictionary, entityName: "MCCategoryTest", context: context)
@@ -243,7 +277,10 @@ class MCCoreDataRepositoryTest: XCTestCase {
         }) { (_) in
 
             self.coreDataRepo.read(operationBlock: { (context) in
-                let results = self.coreDataRepo?.fetch(byPredicate: NSPredicate(format: "%K = %@", "categoryName", "categoryName"), entityName: "MCCategoryTest", context: context, resultType: NSFetchRequestResultType())
+                let predicate = NSPredicate(format: "%K = %@", "categoryName", "categoryName")
+                let results = self.coreDataRepo?.fetch(byPredicate: predicate, entityName: "MCCategoryTest",
+                                                                      context: context,
+                                                                      resultType: NSFetchRequestResultType())
 
                 XCTAssertTrue(results?.count == 1000)
 
@@ -259,7 +296,8 @@ class MCCoreDataRepositoryTest: XCTestCase {
     func testPersist1000CategoriesAndDelete400OfThem_06() {
         self.expectation = self.expectation(description: "Saving 1000 categories in a background queue")
 
-        let dictionary: [String: AnyObject] = ["categoryID": "12345" as AnyObject, "categoryName": "Test12345" as AnyObject]
+        let dictionary: [String: AnyObject] = ["categoryID": "12345" as AnyObject,
+                                               "categoryName": "Test12345" as AnyObject]
 
         self.coreDataRepo.write(operationBlock: { (context) in
             _ = self.coreDataRepo?.create(dictionary: dictionary, entityName: "MCCategoryTest", context: context)
@@ -269,7 +307,8 @@ class MCCoreDataRepositoryTest: XCTestCase {
                 let categoryID = String(index)
                 let categoryName = "categoryName" //"CategoryName" + String(index)
 
-                let dictionary: [String: AnyObject] = ["categoryID": categoryID as AnyObject, "categoryName": categoryName as AnyObject]
+                let dictionary: [String: AnyObject] = ["categoryID": categoryID as AnyObject,
+                                                       "categoryName": categoryName as AnyObject]
 
                 _ = self.coreDataRepo?.create(dictionary: dictionary, entityName: "MCCategoryTest", context: context)
             }
@@ -277,7 +316,11 @@ class MCCoreDataRepositoryTest: XCTestCase {
         }) { (_) in
 
             self.coreDataRepo.read(operationBlock: { (context) in
-                let results = self.coreDataRepo?.fetch(byPredicate: NSPredicate(format: "%K = %@", "categoryName", "categoryName"), entityName: "MCCategoryTest", context: context, resultType: .managedObjectIDResultType)
+                let predicate = NSPredicate(format: "%K = %@", "categoryName", "categoryName")
+                let results = self.coreDataRepo?.fetch(byPredicate: predicate,
+                                                       entityName: "MCCategoryTest",
+                                                       context: context,
+                                                       resultType: .managedObjectIDResultType)
 
                 XCTAssertTrue(results?.count == 1000)
 
@@ -293,7 +336,10 @@ class MCCoreDataRepositoryTest: XCTestCase {
                     self.coreDataRepo.delete(containedInArray: objs, completionBlock: {
 
                         self.coreDataRepo.read(operationBlock: { (context) in
-                            let results = self.coreDataRepo?.fetch(byPredicate: NSPredicate(format: "%K = %@", "categoryName", "categoryName"), entityName: "MCCategoryTest", context: context, resultType: .managedObjectIDResultType)
+                            let results = self.coreDataRepo?.fetch(byPredicate: predicate,
+                                                                   entityName: "MCCategoryTest",
+                                                                   context: context,
+                                                                   resultType: .managedObjectIDResultType)
 
                             XCTAssertTrue(results?.count == 0)
 
@@ -315,7 +361,8 @@ class MCCoreDataRepositoryTest: XCTestCase {
     func testPersist5000CategoriesAndDelete2500OfThem_07() {
         self.expectation = self.expectation(description: "Saving 1000 categories in a background queue")
 
-        let dictionary: [String: AnyObject] = ["categoryID": "12345" as AnyObject, "categoryName": "Test12345" as AnyObject]
+        let dictionary: [String: AnyObject] = ["categoryID": "12345" as AnyObject,
+                                               "categoryName": "Test12345" as AnyObject]
 
         self.coreDataRepo.write(operationBlock: { (context) in
 
@@ -326,14 +373,18 @@ class MCCoreDataRepositoryTest: XCTestCase {
                 let categoryID = String(index)
                 let categoryName = "categoryName" //"CategoryName" + String(index)
 
-                let dictionary: [String: AnyObject] = ["categoryID": categoryID as AnyObject, "categoryName": categoryName as AnyObject]
+                let dictionary: [String: AnyObject] = ["categoryID": categoryID as AnyObject,
+                                                       "categoryName": categoryName as AnyObject]
 
                 _ = self.coreDataRepo?.create(dictionary: dictionary, entityName: "MCCategoryTest", context: context)
             }
 
         }, completion: nil).read { (context) in
-
-            let results = self.coreDataRepo?.fetch(byPredicate: NSPredicate(format: "%K = %@", "categoryName", "categoryName"), entityName: "MCCategoryTest", context: context, resultType: .managedObjectIDResultType)
+            let predicate = NSPredicate(format: "%K = %@", "categoryName", "categoryName")
+            let results = self.coreDataRepo?.fetch(byPredicate: predicate,
+                                                   entityName: "MCCategoryTest",
+                                                   context: context,
+                                                   resultType: .managedObjectIDResultType)
 
             XCTAssertTrue(results?.count == 5000)
 
@@ -351,7 +402,11 @@ class MCCoreDataRepositoryTest: XCTestCase {
                 self.coreDataRepo.delete(containedInArray: subArray, completionBlock: {
 
                     self.coreDataRepo.read(operationBlock: { (context) in
-                        let results = self.coreDataRepo?.fetch(byPredicate: NSPredicate(format: "%K = %@", "categoryName", "categoryName"), entityName: "MCCategoryTest", context: context, resultType: .managedObjectIDResultType)
+                        let predicate = NSPredicate(format: "%K = %@", "categoryName", "categoryName")
+                        let results = self.coreDataRepo?.fetch(byPredicate: predicate,
+                                                               entityName: "MCCategoryTest",
+                                                               context: context,
+                                                               resultType: .managedObjectIDResultType)
 
                         XCTAssertTrue(results?.count == 2500)
 
@@ -369,8 +424,8 @@ class MCCoreDataRepositoryTest: XCTestCase {
     }
 
     func testCoreDataRepositoryObjectCreationAndReadOnMT_PlusUpdateOnBkgAndReadOnMT_08() {
-
-        self.expectation = self.expectation(description: "Create and read on Main Thread - Update in Background and read on Main Thread")
+        let description = "Create and read on Main Thread - Update in Background and read on Main Thread"
+        self.expectation = self.expectation(description: description)
 
         var dataSource: [AnyObject]? = nil
 
@@ -381,9 +436,11 @@ class MCCoreDataRepositoryTest: XCTestCase {
                 let categoryID = String(index)
                 let categoryName = "categoryName"
 
-                let dictionary: [String: AnyObject] = ["categoryID": categoryID as AnyObject, "categoryName": categoryName as AnyObject]
+                let dictionary: [String: AnyObject] = ["categoryID": categoryID as AnyObject,
+                                                       "categoryName": categoryName as AnyObject]
 
-                let createdObject = self.coreDataRepo?.create(dictionary: dictionary, entityName: "MCCategoryTest", context: context)
+                let createdObject = self.coreDataRepo?.create(dictionary: dictionary,
+                                                              entityName: "MCCategoryTest", context: context)
                 XCTAssertFalse(createdObject == nil)
 
             }
@@ -391,7 +448,9 @@ class MCCoreDataRepositoryTest: XCTestCase {
         }) { (_) in
 
             }.read { (context) in
-                dataSource = self.coreDataRepo?.fetch(entityName: "MCCategoryTest", context: context, resultType: NSFetchRequestResultType())
+                dataSource = self.coreDataRepo?.fetch(entityName: "MCCategoryTest",
+                                                      context: context,
+                                                      resultType: NSFetchRequestResultType())
 
                 XCTAssertTrue((dataSource?.count)! > 0)
         }
@@ -411,7 +470,9 @@ class MCCoreDataRepositoryTest: XCTestCase {
         }, { (_) in
 
         }.read_MT { (context) in
-            dataSource = self.coreDataRepo?.fetch(entityName: "MCCategoryTest", context: context, resultType: NSFetchRequestResultType())
+            dataSource = self.coreDataRepo?.fetch(entityName: "MCCategoryTest",
+                                                  context: context,
+                                                  resultType: NSFetchRequestResultType())
 
             for obj in dataSource! {
                 if let category = obj as? MCCategoryTest {

--- a/MCCoreDataStack/MCCoreDataStackTests/CoreDataStackManager/MCCoreDataRepositoryTest.swift
+++ b/MCCoreDataStack/MCCoreDataStackTests/CoreDataStackManager/MCCoreDataRepositoryTest.swift
@@ -33,7 +33,10 @@ class MCCoreDataRepositoryTest: XCTestCase {
         let defaultModelURL = Bundle(for: MCCoreDataRepository.self).url(forResource: modelName, withExtension: "momd")!
 
         self.coreDataRepo = MCCoreDataRepository()
-        self.coreDataRepo.setup(storeNameURL: self.defaultStoreURL, modelNameURL: defaultModelURL, domainName: "co.uk.tests", completion: nil)
+        self.coreDataRepo.setup(storeNameURL: self.defaultStoreURL,
+                                modelNameURL: defaultModelURL,
+                                domainName: "co.uk.tests",
+                                completion: nil)
 
         self.cdsManager = self.coreDataRepo.cdsManager
 
@@ -85,14 +88,13 @@ class MCCoreDataRepositoryTest: XCTestCase {
                 XCTAssertTrue(false)
             }
 
-        }) { (_) in
-
-        }.read { (context) in
+        }, completion: nil).read { (context) in
             let result = self.coreDataRepo?.fetch(entityName: "MCCategoryTest",
                                                   context: context,
                                                   resultType: NSFetchRequestResultType())
 
             for resultItem in result! {
+                // swiftlint:disable:next force_cast
                 let category = resultItem as! MCCategoryTest
 
                 if let subCategory = category.subCategory {
@@ -143,9 +145,7 @@ class MCCoreDataRepositoryTest: XCTestCase {
                 XCTAssertTrue(false)
             }
 
-        }) { (_) in
-
-        }.write(operationBlock: { (context) in
+        }, completion: nil).write(operationBlock: { (context) in
 
                 let results = self.coreDataRepo?.fetch(entityName: "MCCategoryTest",
                                                        context: context,
@@ -154,9 +154,7 @@ class MCCoreDataRepositoryTest: XCTestCase {
                 XCTAssertTrue((results?.count)! > 0)
                 self.coreDataRepo?.delete(containedInArray: results!, context: context)
 
-        }) { (_) in
-
-        }.read_MT { (context) in
+        }, completion: nil).read_MT { (context) in
 
             self.coreDataRepo?.read_MT(operationBlock: { (context) in
                 let results = self.coreDataRepo?.fetch(entityName: "MCCategoryTest",
@@ -187,6 +185,7 @@ class MCCoreDataRepositoryTest: XCTestCase {
             var firstObject: NSManagedObject? = nil
             var duplicatedObject: NSManagedObject? = nil
 
+            // swiftlint:disable:next force_cast
             let predicate = NSPredicate(format: "%K = %@", "categoryID", dictionary["categoryID"] as! String)
             var results = self.coreDataRepo?.fetch(byPredicate: predicate,
                                                    entityName: "MCCategoryTest",
@@ -194,6 +193,7 @@ class MCCoreDataRepositoryTest: XCTestCase {
                                                    resultType: .countResultType)
 
             if let value = results {
+                // swiftlint:disable:next force_cast
                 if value[0] as! NSInteger == 0 {
                     firstObject = self.coreDataRepo?.create(dictionary: dictionary,
                                                             entityName: "MCCategoryTest",
@@ -207,6 +207,7 @@ class MCCoreDataRepositoryTest: XCTestCase {
                                                resultType: .countResultType)
 
             if let value = results {
+                // swiftlint:disable:next force_cast
                 if value[0] as! NSInteger == 0 {
                     duplicatedObject = self.coreDataRepo?.create(dictionary: dictionaryNew,
                                                                  entityName: "MCCategoryTest",
@@ -225,7 +226,7 @@ class MCCoreDataRepositoryTest: XCTestCase {
                 XCTAssertTrue(false)
             }
 
-        }) { (error) in
+        }, completion: { (error) in
 
             XCTAssertTrue(error == nil)
 
@@ -247,7 +248,7 @@ class MCCoreDataRepositoryTest: XCTestCase {
                 }
                 self.expectation.fulfill()
             })
-        }
+        })
 
         self.waitForExpectations(timeout: 10) { (error) -> Void in
             XCTAssertNil(error)
@@ -269,12 +270,13 @@ class MCCoreDataRepositoryTest: XCTestCase {
                 let categoryID = String(index)
                 let categoryName = "categoryName"
 
-                let dictionary: [String: AnyObject] = ["categoryID": categoryID as AnyObject, "categoryName": categoryName as AnyObject]
+                let dictionary: [String: AnyObject] = ["categoryID": categoryID as AnyObject,
+                                                       "categoryName": categoryName as AnyObject]
 
                 _ = self.coreDataRepo?.create(dictionary: dictionary, entityName: "MCCategoryTest", context: context)
             }
 
-        }) { (_) in
+        }, completion: { (_) in
 
             self.coreDataRepo.read(operationBlock: { (context) in
                 let predicate = NSPredicate(format: "%K = %@", "categoryName", "categoryName")
@@ -286,7 +288,7 @@ class MCCoreDataRepositoryTest: XCTestCase {
 
                 self.expectation.fulfill()
             })
-        }
+        })
 
         self.waitForExpectations(timeout: 10) { (error) -> Void in
             XCTAssertNil(error)
@@ -313,7 +315,7 @@ class MCCoreDataRepositoryTest: XCTestCase {
                 _ = self.coreDataRepo?.create(dictionary: dictionary, entityName: "MCCategoryTest", context: context)
             }
 
-        }) { (_) in
+        }, completion: { (_) in
 
             self.coreDataRepo.read(operationBlock: { (context) in
                 let predicate = NSPredicate(format: "%K = %@", "categoryName", "categoryName")
@@ -350,7 +352,7 @@ class MCCoreDataRepositoryTest: XCTestCase {
                 }
 
             })
-        }
+        })
 
         self.waitForExpectations(timeout: 10) { (error) -> Void in
             XCTAssertNil(error)
@@ -445,9 +447,7 @@ class MCCoreDataRepositoryTest: XCTestCase {
 
             }
 
-        }) { (_) in
-
-            }.read { (context) in
+        }, completion: nil).read { (context) in
                 dataSource = self.coreDataRepo?.fetch(entityName: "MCCategoryTest",
                                                       context: context,
                                                       resultType: NSFetchRequestResultType())
@@ -457,8 +457,8 @@ class MCCoreDataRepositoryTest: XCTestCase {
 
         //Here we Update the dataSource in background
 
-        self.coreDataRepo.write(operationBlock: { (context) in
-
+        self.coreDataRepo.write(operationBlock: { context in
+            // swiftlint:disable:next force_cast
             let objs = context.moveInContext(managedObjects: dataSource as! [NSManagedObject])
 
             for obj in objs {
@@ -466,10 +466,7 @@ class MCCoreDataRepositoryTest: XCTestCase {
                     category.categoryName = "UPDATED"
                 }
             }
-
-        }, { (_) in
-
-        }.read_MT { (context) in
+        }, completion: nil).read_MT { context in
             dataSource = self.coreDataRepo?.fetch(entityName: "MCCategoryTest",
                                                   context: context,
                                                   resultType: NSFetchRequestResultType())
@@ -481,7 +478,6 @@ class MCCoreDataRepositoryTest: XCTestCase {
             }
 
             XCTAssertTrue((dataSource?.count)! > 0)
-
             self.expectation.fulfill()
         }
 

--- a/MCCoreDataStack/MCCoreDataStackTests/CoreDataStackManager/MCCoreDataRepositoryTest.swift
+++ b/MCCoreDataStack/MCCoreDataStackTests/CoreDataStackManager/MCCoreDataRepositoryTest.swift
@@ -30,11 +30,12 @@ class MCCoreDataRepositoryTest: XCTestCase
         super.setUp();
         
         let dirPath = StackManagerHelper.Path.DocumentsFolder
-        
         self.defaultStoreURL = URL(fileURLWithPath: dirPath + "/TestDB.sqlite")
-        
+        let modelName = "TestModel"
+        let defaultModelURL = Bundle(for: MCCoreDataRepository.self).url(forResource: modelName, withExtension: "momd")!
+
         self.coreDataRepo = MCCoreDataRepository()
-        self.coreDataRepo.setup(storeName: "TestDB.sqlite", domainName: "co.uk.tests", completion: nil)
+        self.coreDataRepo.setup(storeNameURL: self.defaultStoreURL, modelNameURL: defaultModelURL, domainName: "co.uk.tests", completion: nil)
         
         self.cdsManager = self.coreDataRepo.cdsManager
         

--- a/MCCoreDataStack/MCCoreDataStackTests/CoreDataStackManager/MCCoreDataRepositoryTest.swift
+++ b/MCCoreDataStack/MCCoreDataStackTests/CoreDataStackManager/MCCoreDataRepositoryTest.swift
@@ -11,24 +11,22 @@ import CoreData
 
 @testable import MCCoreDataStack
 
-class MCCoreDataRepositoryTest: XCTestCase
-{
+class MCCoreDataRepositoryTest: XCTestCase {
     fileprivate var defaultStoreURL: URL!
     fileprivate var defaultModelURL: URL!
     fileprivate var coreDataRepo: MCCoreDataRepository!
     fileprivate var expectation: XCTestExpectation!
     fileprivate var cdsManager: MCCoreDataStackManager!
-    
+
     lazy var backgroundcontext: NSManagedObjectContext = {
         let bkgQueue = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
         bkgQueue.mergePolicy = NSMergePolicy(merge: .overwriteMergePolicyType)
         return bkgQueue
     }()
-    
-    override func setUp()
-    {
-        super.setUp();
-        
+
+    override func setUp() {
+        super.setUp()
+
         let dirPath = StackManagerHelper.Path.DocumentsFolder
         self.defaultStoreURL = URL(fileURLWithPath: dirPath + "/TestDB.sqlite")
         let modelName = "TestModel"
@@ -36,46 +34,44 @@ class MCCoreDataRepositoryTest: XCTestCase
 
         self.coreDataRepo = MCCoreDataRepository()
         self.coreDataRepo.setup(storeNameURL: self.defaultStoreURL, modelNameURL: defaultModelURL, domainName: "co.uk.tests", completion: nil)
-        
+
         self.cdsManager = self.coreDataRepo.cdsManager
-        
+
         self.cdsManager.deleteStore {
-            
-        };
+
+        }
         sleep(2)
     }
-    
+
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
-        self.cdsManager.deleteStore { 
-            
-        };
+        self.cdsManager.deleteStore {
+
+        }
         sleep(2)
     }
-    
-    func testCoreDataRepositoryCreation_01()
-    {
+
+    func testCoreDataRepositoryCreation_01() {
             XCTAssertFalse(self.coreDataRepo == nil)
     }
-    
-    func testCoreDataRepositoryObjectCreationAndSave_02()
-    {
+
+    func testCoreDataRepositoryObjectCreationAndSave_02() {
 
         self.expectation = self.expectation(description: "Create and save object")
 
         let subDictionary: [String: AnyObject] = ["subCategoryID": "sub12345" as AnyObject, "subCategoryName": "subTest12345" as AnyObject]
 
         let dictionary: [String: AnyObject] = ["categoryID": "12345" as AnyObject, "categoryName": "Test12345" as AnyObject, "subCategory": subDictionary as AnyObject]
-        
+
         self.coreDataRepo.write(operationBlock: { (context) in
 
             let createdObject = self.coreDataRepo?.create(dictionary: dictionary, entityName: "MCCategoryTest", context: context)
-            
+
             XCTAssertFalse(createdObject == nil)
-            
+
             if let category = createdObject as? MCCategoryTest {
-                
+
                 XCTAssertTrue(category.categoryID == "12345")
                 XCTAssertTrue(category.categoryName == "Test12345")
                 XCTAssertTrue(category.subCategory?.subCategoryID == "sub12345")
@@ -83,16 +79,15 @@ class MCCoreDataRepositoryTest: XCTestCase
             } else {
                 XCTAssertTrue(false)
             }
-            
-        }) { (error) in
-            
-            
+
+        }) { (_) in
+
         }.read { (context) in
             let result = self.coreDataRepo?.fetch(entityName: "MCCategoryTest", context: context, resultType: NSFetchRequestResultType())
-            
+
             for resultItem in result! {
                 let category = resultItem as! MCCategoryTest
-                
+
                 if let subCategory = category.subCategory {
                     XCTAssertTrue(subCategory.subCategoryID == "sub12345")
                     XCTAssertTrue(subCategory.subCategoryName == "subTest12345")
@@ -100,102 +95,100 @@ class MCCoreDataRepositoryTest: XCTestCase
                     XCTAssertTrue(subCategory.parent?.categoryName == "Test12345")
                 }
             }
-            
+
             self.expectation.fulfill()
         }
-        
+
         self.waitForExpectations(timeout: 10) { (error) -> Void in
-            XCTAssertNil(error);
+            XCTAssertNil(error)
         }
 
     }
-    
-    func testCoreDataRepositoryObjectCreationSaveAndDeletion_03()
-    {
-        
+
+    func testCoreDataRepositoryObjectCreationSaveAndDeletion_03() {
+
         self.expectation = self.expectation(description: "Create and save object")
-        
+
         let subDictionary: [String: AnyObject] = ["subCategoryID": "sub12345" as AnyObject, "subCategoryName": "subTest12345" as AnyObject]
-        
+
         let dictionary: [String: AnyObject] = ["categoryID": "12345" as AnyObject, "categoryName": "Test12345" as AnyObject, "subCategory": subDictionary as AnyObject]
-        
+
         self.coreDataRepo.write(operationBlock: { (context) in
             let createdObject = self.coreDataRepo?.create(dictionary: dictionary, entityName: "MCCategoryTest", context: context)
-            
+
             XCTAssertFalse(createdObject == nil)
-            
+
             if let category = createdObject as? MCCategoryTest {
                 XCTAssertTrue(category.categoryID == "12345")
                 XCTAssertTrue(category.categoryName == "Test12345")
-                
+
                 if let subCategory = category.subCategory {
                     XCTAssertTrue(subCategory.subCategoryID == "sub12345")
                     XCTAssertTrue(subCategory.subCategoryName == "subTest12345")
                 }
-                
+
             } else {
                 XCTAssertTrue(false)
             }
 
-        }) { (error) in
-        
+        }) { (_) in
+
         }.write(operationBlock: { (context) in
-                         
+
                 let results = self.coreDataRepo?.fetch(entityName: "MCCategoryTest", context: context, resultType: NSFetchRequestResultType()) as? [NSManagedObject]
-                
+
                 XCTAssertTrue((results?.count)! > 0)
                 self.coreDataRepo?.delete(containedInArray: results!, context: context)
 
-        }) { (error) in
-            
+        }) { (_) in
+
         }.read_MT { (context) in
-            
+
             self.coreDataRepo?.read_MT(operationBlock: { (context) in
                 let results = self.coreDataRepo?.fetch(entityName: "MCCategoryTest", context: context, resultType: NSFetchRequestResultType()) as? [NSManagedObject]
                 XCTAssertTrue(results?.count == 0)
                 self.expectation.fulfill()
             })
-            
+
         }
-        
+
         self.waitForExpectations(timeout: 10) { (error) -> Void in
-            XCTAssertNil(error);
+            XCTAssertNil(error)
         }
-        
+
     }
 
-    func testCoreDataRepositoryObjectShouldBeOverridenWhenCreatingADuplicate_04()
-    {
-        
+    func testCoreDataRepositoryObjectShouldBeOverridenWhenCreatingADuplicate_04() {
+
         self.expectation = self.expectation(description: "Create and save object")
-        
+
         let dictionary: [String: AnyObject] = ["categoryID": "12345" as AnyObject, "categoryName": "Test12345" as AnyObject]
         let dictionaryNew: [String: AnyObject] = ["categoryID": "12345" as AnyObject, "categoryName": "Test" as AnyObject]
-        
+
         self.coreDataRepo.write(operationBlock: { (context) in
             var firstObject: NSManagedObject? = nil
             var duplicatedObject: NSManagedObject? = nil
-            
+
             var results = self.coreDataRepo?.fetch(byPredicate: NSPredicate(format: "%K = %@", "categoryID", dictionary["categoryID"] as! String), entityName: "MCCategoryTest", context: context, resultType: .countResultType)
-            
+
             if let value = results {
                 if value[0] as! NSInteger == 0 {
                     firstObject = self.coreDataRepo?.create(dictionary: dictionary, entityName: "MCCategoryTest", context: context)
                 }
             }
-            
+
             results = self.coreDataRepo?.fetch(byPredicate: NSPredicate(format: "%K = %@", "categoryID", dictionaryNew["categoryID"] as! String), entityName: "MCCategoryTest", context: context, resultType: .countResultType)
-            
+
             if let value = results {
                 if value[0] as! NSInteger == 0 {
                     duplicatedObject = self.coreDataRepo?.create(dictionary: dictionaryNew, entityName: "MCCategoryTest", context: context)
                 }
             }
-            
+
             XCTAssertFalse(firstObject == nil)
-            
+
             XCTAssertTrue(duplicatedObject == nil, "This object should be nil because it was duplicated")
-            
+
             if let category = firstObject as? MCCategoryTest {
                 XCTAssertTrue(category.categoryID == "12345")
                 XCTAssertTrue(category.categoryName == "Test12345")
@@ -204,16 +197,16 @@ class MCCoreDataRepositoryTest: XCTestCase
             }
 
         }) { (error) in
-            
+
             XCTAssertTrue(error == nil)
-            
+
             self.coreDataRepo.read(operationBlock: { (context) in
                 let results = self.coreDataRepo?.fetch(byPredicate: NSPredicate(format: "%K = %@", "categoryID", "12345"), entityName: "MCCategoryTest", context: context, resultType: NSFetchRequestResultType())
-                
+
                 if let value = results {
                     XCTAssertTrue(value.count == 1)
                 }
-                
+
                 if let category = results![0] as? MCCategoryTest {
                     XCTAssertFalse(category.hasChanges)
                 } else {
@@ -222,231 +215,219 @@ class MCCoreDataRepositoryTest: XCTestCase
                 self.expectation.fulfill()
             })
         }
-        
+
         self.waitForExpectations(timeout: 10) { (error) -> Void in
-            XCTAssertNil(error);
+            XCTAssertNil(error)
         }
-        
+
     }
-    
-    func testPersist1000CategoriesWithCommonCategoryNameAndRetrieveThemByCategoryName_05()
-    {
+
+    func testPersist1000CategoriesWithCommonCategoryNameAndRetrieveThemByCategoryName_05() {
         self.expectation = self.expectation(description: "Saving 1000 categories in a background queue")
-        
+
         let dictionary: [String: AnyObject] = ["categoryID": "12345" as AnyObject, "categoryName": "Test12345" as AnyObject]
-        
+
         self.coreDataRepo.write(operationBlock: { (context) in
             _ = self.coreDataRepo?.create(dictionary: dictionary, entityName: "MCCategoryTest", context: context)
-            
+
             for index in 1...1000 {
-                
+
                 let categoryID = String(index)
                 let categoryName = "categoryName"
-                
+
                 let dictionary: [String: AnyObject] = ["categoryID": categoryID as AnyObject, "categoryName": categoryName as AnyObject]
-                
+
                 _ = self.coreDataRepo?.create(dictionary: dictionary, entityName: "MCCategoryTest", context: context)
             }
-            
 
-        }) { (error) in
-            
+        }) { (_) in
+
             self.coreDataRepo.read(operationBlock: { (context) in
                 let results = self.coreDataRepo?.fetch(byPredicate: NSPredicate(format: "%K = %@", "categoryName", "categoryName"), entityName: "MCCategoryTest", context: context, resultType: NSFetchRequestResultType())
-                
+
                 XCTAssertTrue(results?.count == 1000)
-                
+
                 self.expectation.fulfill()
             })
         }
-        
+
         self.waitForExpectations(timeout: 10) { (error) -> Void in
-            XCTAssertNil(error);
+            XCTAssertNil(error)
         }
     }
 
-    func testPersist1000CategoriesAndDelete400OfThem_06()
-    {
+    func testPersist1000CategoriesAndDelete400OfThem_06() {
         self.expectation = self.expectation(description: "Saving 1000 categories in a background queue")
-        
+
         let dictionary: [String: AnyObject] = ["categoryID": "12345" as AnyObject, "categoryName": "Test12345" as AnyObject]
-        
-        
+
         self.coreDataRepo.write(operationBlock: { (context) in
             _ = self.coreDataRepo?.create(dictionary: dictionary, entityName: "MCCategoryTest", context: context)
-            
+
             for index in 1...1000 {
-                
+
                 let categoryID = String(index)
                 let categoryName = "categoryName" //"CategoryName" + String(index)
-                
+
                 let dictionary: [String: AnyObject] = ["categoryID": categoryID as AnyObject, "categoryName": categoryName as AnyObject]
-                
+
                 _ = self.coreDataRepo?.create(dictionary: dictionary, entityName: "MCCategoryTest", context: context)
             }
 
-        }) { (error) in
-            
+        }) { (_) in
+
             self.coreDataRepo.read(operationBlock: { (context) in
                 let results = self.coreDataRepo?.fetch(byPredicate: NSPredicate(format: "%K = %@", "categoryName", "categoryName"), entityName: "MCCategoryTest", context: context, resultType: .managedObjectIDResultType)
-                
+
                 XCTAssertTrue(results?.count == 1000)
-                
+
                 if let array = results! as? [NSManagedObjectID] {
-                    
+
                     let ctx = self.cdsManager.createPrivatecontext()
-                    
+
                     //Checking that we can retrieve existingObjecsWithIds
                     let objs = ctx.existingObjecsWithIds(managedObjects: array)
-                    
+
                     XCTAssertTrue(objs.count == 1000)
-                    
+
                     self.coreDataRepo.delete(containedInArray: objs, completionBlock: {
-                        
+
                         self.coreDataRepo.read(operationBlock: { (context) in
                             let results = self.coreDataRepo?.fetch(byPredicate: NSPredicate(format: "%K = %@", "categoryName", "categoryName"), entityName: "MCCategoryTest", context: context, resultType: .managedObjectIDResultType)
-                            
+
                             XCTAssertTrue(results?.count == 0)
-                            
+
                             self.expectation.fulfill()
                         })
-                        
+
                     })
                 }
 
             })
         }
-        
+
         self.waitForExpectations(timeout: 10) { (error) -> Void in
-            XCTAssertNil(error);
+            XCTAssertNil(error)
         }
 
     }
 
-    func testPersist5000CategoriesAndDelete2500OfThem_07()
-    {
+    func testPersist5000CategoriesAndDelete2500OfThem_07() {
         self.expectation = self.expectation(description: "Saving 1000 categories in a background queue")
-        
+
         let dictionary: [String: AnyObject] = ["categoryID": "12345" as AnyObject, "categoryName": "Test12345" as AnyObject]
-        
-        
+
         self.coreDataRepo.write(operationBlock: { (context) in
 
             _ = self.coreDataRepo?.create(dictionary: dictionary, entityName: "MCCategoryTest", context: context)
-            
+
             for index in 1...5000 {
-                
+
                 let categoryID = String(index)
                 let categoryName = "categoryName" //"CategoryName" + String(index)
-                
+
                 let dictionary: [String: AnyObject] = ["categoryID": categoryID as AnyObject, "categoryName": categoryName as AnyObject]
-                
+
                 _ = self.coreDataRepo?.create(dictionary: dictionary, entityName: "MCCategoryTest", context: context)
             }
 
         }, completion: nil).read { (context) in
-            
+
             let results = self.coreDataRepo?.fetch(byPredicate: NSPredicate(format: "%K = %@", "categoryName", "categoryName"), entityName: "MCCategoryTest", context: context, resultType: .managedObjectIDResultType)
-            
+
             XCTAssertTrue(results?.count == 5000)
-            
+
             if var array = results! as? [NSManagedObjectID] {
-                
+
                 let ctx = self.cdsManager.createPrivatecontext()
                 //Checking that we can retrieve existingObjecsWithIds
                 let objs = ctx.existingObjecsWithIds(managedObjects: array)
                 XCTAssertTrue(objs.count == 5000)
-                
+
                 array.removeSubrange(0..<2500)
-                
+
                 let subArray = array as [NSManagedObjectID]
-                
+
                 self.coreDataRepo.delete(containedInArray: subArray, completionBlock: {
-                    
+
                     self.coreDataRepo.read(operationBlock: { (context) in
                         let results = self.coreDataRepo?.fetch(byPredicate: NSPredicate(format: "%K = %@", "categoryName", "categoryName"), entityName: "MCCategoryTest", context: context, resultType: .managedObjectIDResultType)
-                        
+
                         XCTAssertTrue(results?.count == 2500)
-                        
+
                         self.expectation.fulfill()
                     })
-                    
+
                 })
             }
         }
-        
+
         self.waitForExpectations(timeout: 10) { (error) -> Void in
-            XCTAssertNil(error);
+            XCTAssertNil(error)
         }
-        
+
     }
-    
-    func testCoreDataRepositoryObjectCreationAndReadOnMT_PlusUpdateOnBkgAndReadOnMT_08()
-    {
-        
+
+    func testCoreDataRepositoryObjectCreationAndReadOnMT_PlusUpdateOnBkgAndReadOnMT_08() {
+
         self.expectation = self.expectation(description: "Create and read on Main Thread - Update in Background and read on Main Thread")
-        
+
         var dataSource: [AnyObject]? = nil
-        
+
         self.coreDataRepo.write(operationBlock: { (context) in
-            
+
             for index in 0..<5000 {
-                
+
                 let categoryID = String(index)
                 let categoryName = "categoryName"
-                
+
                 let dictionary: [String: AnyObject] = ["categoryID": categoryID as AnyObject, "categoryName": categoryName as AnyObject]
-                
+
                 let createdObject = self.coreDataRepo?.create(dictionary: dictionary, entityName: "MCCategoryTest", context: context)
                 XCTAssertFalse(createdObject == nil)
 
             }
 
-            
-        }) { (error) in
-            
-            
+        }) { (_) in
+
             }.read { (context) in
                 dataSource = self.coreDataRepo?.fetch(entityName: "MCCategoryTest", context: context, resultType: NSFetchRequestResultType())
-                
+
                 XCTAssertTrue((dataSource?.count)! > 0)
         }
-        
+
         //Here we Update the dataSource in background
-        
+
         self.coreDataRepo.write(operationBlock: { (context) in
-            
+
             let objs = context.moveInContext(managedObjects: dataSource as! [NSManagedObject])
 
-            for obj in objs
-            {
+            for obj in objs {
                 if let category = obj as? MCCategoryTest {
                     category.categoryName = "UPDATED"
                 }
             }
-            
-            }) { (error) in
-                
+
+        }, { (_) in
+
         }.read_MT { (context) in
             dataSource = self.coreDataRepo?.fetch(entityName: "MCCategoryTest", context: context, resultType: NSFetchRequestResultType())
 
-            for obj in dataSource!
-            {
+            for obj in dataSource! {
                 if let category = obj as? MCCategoryTest {
                     XCTAssertTrue(category.categoryName == "UPDATED")
                 }
             }
 
             XCTAssertTrue((dataSource?.count)! > 0)
-            
+
             self.expectation.fulfill()
         }
-        
-        
+
         self.waitForExpectations(timeout: 10) { (error) -> Void in
-            XCTAssertNil(error);
+            XCTAssertNil(error)
         }
-        
+
     }
-    
+
 }

--- a/MCCoreDataStack/MCCoreDataStackTests/CoreDataStackManager/MCCoreDataStackManagerTest.swift
+++ b/MCCoreDataStack/MCCoreDataStackTests/CoreDataStackManager/MCCoreDataStackManagerTest.swift
@@ -11,43 +11,40 @@ import CoreData
 
 @testable import MCCoreDataStack
 
-class MCCoreDataStackManagerTest: XCTestCase
-{
+class MCCoreDataStackManagerTest: XCTestCase {
     fileprivate var defaultStoreURL: URL!
     fileprivate var coreDataRepo: MCCoreDataRepository!
     fileprivate var expectation: XCTestExpectation!
-    
+
     lazy var backgroundcontext: NSManagedObjectContext = {
         let bkgQueue = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
         bkgQueue.mergePolicy = NSMergePolicy(merge: .overwriteMergePolicyType)
         return bkgQueue
     }()
-    
-    override func setUp()
-    {
-        super.setUp();
+
+    override func setUp() {
+        super.setUp()
         let dirPath = StackManagerHelper.Path.DocumentsFolder
-        
+
         self.defaultStoreURL = URL(fileURLWithPath: dirPath + "/UnitTestsModel.sqlite")
     }
-    
+
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
         let dirPath = StackManagerHelper.Path.DocumentsFolder
-        
+
         if FileManager.default.fileExists(atPath: dirPath + "/UnitTestsModel.sqlite") {
             do {
                 try FileManager.default.removeItem(atPath: dirPath + "/UnitTestsModel.sqlite")
-            }catch {
-                
+            } catch {
+
             }
         }
     }
-    
-    func testCoreDataStackCreation01()
-    {
-        
+
+    func testCoreDataStackCreation01() {
+
         let bundle = Bundle(for: type(of: self))
         let managedObjectModel = NSManagedObjectModel.mergedModel(from: [bundle])!
         let cdsManager = MCCoreDataStackManager(domain: "uk.co.mccoredtastack.test", model: managedObjectModel)

--- a/MCCoreDataStack/MCCoreDataStackTests/Models/MCCategoryTest.swift
+++ b/MCCoreDataStack/MCCoreDataStackTests/Models/MCCategoryTest.swift
@@ -14,38 +14,34 @@ class MCCategoryTest: NSManagedObject {
 
 // Insert code here to add functionality to your managed object subclass
 
-    override internal func update(keyName: String, array: Array<Dictionary<String, AnyObject>>)
-    {
+    override  func update(keyName: String, array: Array<Dictionary<String, AnyObject>>) {
         if let entityName = self.getEntity(keyName) {
-            
+
             for dict in array {
-                
+
                 let entity = NSEntityDescription.insertNewObject(forEntityName: entityName, into: self.managedObjectContext!)
                 entity.updateWithDictionary(dictionary: dict)
-                
+
                 switch entityName {
                 case "MCSubCategoryTest":
                     self.subCategory = (entity as! MCSubCategoryTest)
-                    
+
                     break
                 default: break
                 }
             }
         }
     }
-    
-    
-    fileprivate func getEntity(_ keyName: String) -> String?
-    {
+
+    fileprivate func getEntity(_ keyName: String) -> String? {
         switch keyName {
         case "subCategory":
             return "MCSubCategoryTest"
         default:
             break
-            
+
         }
         return nil
     }
 
-    
 }

--- a/MCCoreDataStack/MCCoreDataStackTests/Models/MCCategoryTest.swift
+++ b/MCCoreDataStack/MCCoreDataStackTests/Models/MCCategoryTest.swift
@@ -14,12 +14,13 @@ class MCCategoryTest: NSManagedObject {
 
 // Insert code here to add functionality to your managed object subclass
 
-    override  func update(keyName: String, array: Array<Dictionary<String, AnyObject>>) {
+    override  func update(keyName: String, array: [[String: AnyObject]]) {
         if let entityName = self.getEntity(keyName) {
 
             for dict in array {
 
-                let entity = NSEntityDescription.insertNewObject(forEntityName: entityName, into: self.managedObjectContext!)
+                let entity = NSEntityDescription.insertNewObject(forEntityName: entityName,
+                                                                 into: self.managedObjectContext!)
                 entity.updateWithDictionary(dictionary: dict)
 
                 switch entityName {

--- a/MCCoreDataStack/MCCoreDataStackTests/Models/MCCategoryTest.swift
+++ b/MCCoreDataStack/MCCoreDataStackTests/Models/MCCategoryTest.swift
@@ -25,6 +25,7 @@ class MCCategoryTest: NSManagedObject {
 
                 switch entityName {
                 case "MCSubCategoryTest":
+                    // swiftlint:disable:next force_cast
                     self.subCategory = (entity as! MCSubCategoryTest)
 
                     break

--- a/MCCoreDataStack/MCCoreDataStackUITests/MCCoreDataStackUITests.swift
+++ b/MCCoreDataStack/MCCoreDataStackUITests/MCCoreDataStackUITests.swift
@@ -9,28 +9,12 @@
 import XCTest
 
 class MCCoreDataStackUITests: XCTestCase {
-        
+
     override func setUp() {
         super.setUp()
-        
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-        
-        // In UI tests it is usually best to stop immediately when a failure occurs.
-        continueAfterFailure = false
-        // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
-        XCUIApplication().launch()
 
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+        continueAfterFailure = false
+
+        XCUIApplication().launch()
     }
-    
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-    
-    func testExample() {
-        // Use recording to get started writing UI tests.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-    
 }


### PR DESCRIPTION
- Conversion to Swift 4 and run of Swiftlint: fixed a lot of warnings and errors, creating a more readable code using syntactic sugar.
- Used optional chain while executing optional completion blocks
- Changed fileprivate to be private (swift 4 changed scope)
- Tests succeed correctly.